### PR TITLE
Switch from pycrypto to pycryptodome

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,7 +21,6 @@ gunicorn = "==19.7.1"
 idna = "==2.6"
 json-flatten = "==0.1"
 psycopg2 = "==2.7.3.2"
-pycrypto = "==2.6.1"
 python-dateutil = "==2.8.0"
 pytz = "==2017.3"
 redis = "==3.2.1"
@@ -33,6 +32,7 @@ six = "==1.11.0"
 urllib3 = "==1.24.2"
 whitenoise = "==3.3.1"
 python-dotenv = "*"
+pycryptodome = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c9969a86122cbfc1fdebb4bdd56c45a893b0e9674d60e59f32f9be1282c8dca9"
+            "sha256": "434ecc4ae13cfc003422c2117df47a36587550d6b405dd163ea79099866d5e4e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -179,12 +179,41 @@
             "index": "pypi",
             "version": "==2.7.3.2"
         },
-        "pycrypto": {
+        "pycryptodome": {
             "hashes": [
-                "sha256:f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
+                "sha256:07024fc364869eae8d6ac0d316e089956e6aeffe42dbdcf44fe1320d96becf7f",
+                "sha256:09b6d6bcc01a4eb1a2b4deeff5aa602a108ec5aed8ac75ae554f97d1d7f0a5ad",
+                "sha256:0e10f352ccbbcb5bb2dc4ecaf106564e65702a717d72ab260f9ac4c19753cfc2",
+                "sha256:1f4752186298caf2e9ff5354f2e694d607ca7342aa313a62005235d46e28cf04",
+                "sha256:2fbc472e0b567318fe2052281d5a8c0ae70099b446679815f655e9fbc18c3a65",
+                "sha256:3ec3dc2f80f71fd0c955ce48b81bfaf8914c6f63a41a738f28885a1c4892968a",
+                "sha256:426c188c83c10df71f053e04b4003b1437bae5cb37606440e498b00f160d71d0",
+                "sha256:626c0a1d4d83ec6303f970a17158114f75c3ba1736f7f2983f7b40a265861bd8",
+                "sha256:767ad0fb5d23efc36a4d5c2fc608ac603f3de028909bcf59abc943e0d0bc5a36",
+                "sha256:7ac729d9091ed5478af2b4a4f44f5335a98febbc008af619e4569a59fe503e40",
+                "sha256:83295a3fb5cf50c48631eb5b440cb5e9832d8c14d81d1d45f4497b67a9987de8",
+                "sha256:8be56bde3312e022d9d1d6afa124556460ad5c844c2fc63642f6af723c098d35",
+                "sha256:8f06556a8f7ea7b1e42eff39726bb0dca1c251205debae64e6eebea3cd7b438a",
+                "sha256:9230fcb5d948c3fb40049bace4d33c5d254f8232c2c0bba05d2570aea3ba4520",
+                "sha256:9378c309aec1f8cd8bad361ed0816a440151b97a2a3f6ffdaba1d1a1fb76873a",
+                "sha256:9977086e0f93adb326379897437373871b80501e1d176fec63c7f46fb300c862",
+                "sha256:9a94fca11fdc161460bd8659c15b6adef45c1b20da86402256eaf3addfaab324",
+                "sha256:9c739b7795ccf2ef1fdad8d44e539a39ad300ee6786e804ea7f0c6a786eb5343",
+                "sha256:b1e332587b3b195542e77681389c296e1837ca01240399d88803a075447d3557",
+                "sha256:c109a26a21f21f695d369ff9b87f5d43e0d6c768d8384e10bc74142bed2e092e",
+                "sha256:c818dc1f3eace93ee50c2b6b5c2becf7c418fa5dd1ba6fc0ef7db279ea21d5e4",
+                "sha256:cff31f5a8977534f255f729d5d2467526f2b10563a30bbdade92223e0bf264bd",
+                "sha256:d4f94368ce2d65873a87ad867eb3bf63f4ba81eb97a9ee66d38c2b71ce5a7439",
+                "sha256:d61b012baa8c2b659e9890011358455c0019a4108536b811602d2f638c40802a",
+                "sha256:d6e1bc5c94873bec742afe2dfadce0d20445b18e75c47afc0c115b19e5dd38dd",
+                "sha256:ea83bcd9d6c03248ebd46e71ac313858e0afd5aa2fa81478c0e653242f3eb476",
+                "sha256:ed5761b37615a1f222c5345bbf45272ae2cf8c7dff88a4f53a1e9f977cbb6d95",
+                "sha256:f011cd0062e54658b7086a76f8cf0f4222812acc66e219e196ea2d0a8849d0ed",
+                "sha256:f1add21b6d179179b3c177c33d18a2186a09cc0d3af41ff5ed3f377360b869f2",
+                "sha256:f655addaaaa9974108d4808f4150652589cada96074c87115c52e575bfcd87d5"
             ],
             "index": "pypi",
-            "version": "==2.6.1"
+            "version": "==3.9.7"
         },
         "python-dateutil": {
             "hashes": [

--- a/mxv/simple_encryption.py
+++ b/mxv/simple_encryption.py
@@ -2,7 +2,7 @@ from Crypto.Cipher import AES
 import base64
 import hashlib
 
-# key or IV generation (from https://pypi.org/project/pycrypto/): 
+# key or IV generation (from https://pypi.org/project/pycryptodome/): 
 #
 # from django.utils.crypto import get_random_string
 # get_random_string(50)


### PR DESCRIPTION
Pycrypto is no longer maintained and has known vulnerabilities. Pycryptodome is backward-compatible and recommended. 

We aren't really using this yet; it was added by @mark-reardon-momentum in the fall in preparation for linking to the NCG elections that had been a possibility in 2019.
