### PR TITLE
Get basic functionality for edit-profile back up

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Do you have development skills (see below for the technologies we've used)?  The
 9. `yarn develop` to run the application locally.
 	- Site accessible at [http://localhost:8000](http://localhost:8000).
 	- Admin site accessible at [http://localhost:8000/admin](http://localhost:8000/admin).
+10. `yarn test` to run unit tests, of which there are only a few.
 
 ### Bookmarks
 

--- a/members/admin.py
+++ b/members/admin.py
@@ -148,7 +148,7 @@ class ProfileFieldAdminForm(forms.ModelForm):
         super(ProfileFieldAdminForm, self).__init__(*args, **kwargs)
         nb = NationBuilder()
         if not self.current_user.nation_builder_person.nation_builder_id:
-            self.current_user.nation_builder_person.nation_builder_id = nb.GetIdFromEmail(self.current_user.email)
+            self.current_user.nation_builder_person.nation_builder_id = nb.GetFromEmail(self.current_user.email)['id']
             self.current_user.save()
         self.fields['field_path'].choices = [(field[0], field[2]) for field in nb.PersonFieldsAndValues(self.current_user.nation_builder_person.nation_builder_id)]
         self.fields['field_path'].help_text = 'Example field values are from your NationBuilder record (id = %d)' % self.current_user.nation_builder_person.nation_builder_id
@@ -199,7 +199,7 @@ class CampaignFieldInline(nested.NestedTabularInline):
         if db_field.name == 'field_path':
             nb = NationBuilder()
             if not request.user.nation_builder_person.nation_builder_id:
-                request.user.nation_builder_person.nation_builder_id = nb.GetIdFromEmail(request.user.email)
+                request.user.nation_builder_person.nation_builder_id = nb.GetFromEmail(request.user.email)['id']
                 request.user.save()
             db_field.choices = [(field[0], field[2]) for field in nb.PersonFieldsAndValues(request.user.nation_builder_person.nation_builder_id)]
             db_field.help_text = 'Example field values are from your NationBuilder record (id = %d)' % request.user.nation_builder_person.nation_builder_id

--- a/members/tests.py
+++ b/members/tests.py
@@ -1,3 +1,58 @@
 from django.test import TestCase
+from members.models import *
+from members.views import *
+from unittest.mock import MagicMock
+from mxv.nation_builder import NationBuilder
 
-# Create your tests here.
+class TestEnsureNationBuilderPerson(TestCase):
+    def setUp(self):
+        self.nb = MagicMock()
+        self.nb.GetFromEmail.return_value = { 
+            'id': 999, 
+            'email': 'haha@gmail.com', 
+            'my_momentum_unique_token': 'aaa'
+        }
+
+    ## Naming conventions used in these tests:
+    ## c - object created before the test
+    ## e - object we're going to ensure
+    ## m - object we'll retrieve from the DB and check
+
+    def test_attached(self):
+        c = Member.objects.create(email='m@jill.com', name='Correct record')
+        NationBuilderPerson.objects.create(nation_builder_id=111, member=c, email=c.email)
+        e = Member.objects.get(email='m@jill.com')
+        ensure_nationbuilder_person(self.nb, e)
+        m = Member.objects.get(email='m@jill.com')
+        self.assertEqual(111, m.nation_builder_person.nation_builder_id)
+        self.assertEqual(m.nation_builder_person.email, m.email)
+        self.nb.GetFromEmail.assert_not_called()
+
+    def test_attached_missing_id(self):
+        c = Member.objects.create(email='nye@bevan.com', name='Missing ID')
+        NationBuilderPerson.objects.create(member=c, email=c.email)
+        e = Member.objects.get(email='nye@bevan.com')
+        ensure_nationbuilder_person(self.nb, e)
+        m = Member.objects.get(email='nye@bevan.com')
+        self.assertEqual(999, m.nation_builder_person.nation_builder_id)
+        self.assertEqual('haha@gmail.com', m.nation_builder_person.email)
+        self.assertEqual('aaa', m.nation_builder_person.unique_token)
+
+    def test_detached(self):
+        NationBuilderPerson.objects.create(nation_builder_id=222, email='notmember@gmail.com')
+        e = Member.objects.create(email='notmember@gmail.com', name='Just joined')
+        ensure_nationbuilder_person(self.nb, e)
+        m = Member.objects.get(email='notmember@gmail.com')
+        self.assertEqual(222, m.nation_builder_person.nation_builder_id)
+        self.assertEqual(m.nation_builder_person.email, m.email)
+        self.nb.GetFromEmail.assert_not_called()
+
+    def test_detached_missing_id(self):
+        NationBuilderPerson.objects.create(email='notmembernoid@gmail.com')
+        e = Member.objects.create(email='notmembernoid@gmail.com', name='Just joined')
+        ensure_nationbuilder_person(self.nb, e)
+        m = Member.objects.get(email='notmembernoid@gmail.com')
+        self.assertEqual(999, m.nation_builder_person.nation_builder_id)
+        self.assertEqual('haha@gmail.com', m.nation_builder_person.email)
+        self.assertEqual('aaa', m.nation_builder_person.unique_token)
+

--- a/members/views.py
+++ b/members/views.py
@@ -18,6 +18,7 @@ from mxv.nation_builder import NationBuilder
 from mxv.simple_email import send_simple_email
 import json
 from django.db.models import Q
+import logging
 
 # signals that a conflict occurred
 
@@ -229,6 +230,40 @@ def request_activation_email(request):
 def profile_error_mailto(name):
     return 'mailto:membership@peoplesmomentum.com?subject=Profile%20error&body=Hi.%0A%0A%20%20I%20tried%20to%20access%20my%20profile%20page%20on%20My%20Momentum%20but%20got%20an%20error%3A%20%22Can%27t%20look%20up%20profile.%22%0A%0A%20%20Can%20you%20help%20please%3F%0A%0AThanks%2C%0A%0A' + name + '.'
 
+def populate_from_nb(nb, email, nb_person):
+    nb_record = nb.GetFromEmail(email)
+    nb_person.nation_builder_id = nb_record['id']
+    nb_person.email = nb_record['email']
+    if nb_record['my_momentum_unique_token']:
+       nb_person.unique_token = nb_record['my_momentum_unique_token']
+    nb_person.save()
+
+
+def ensure_nationbuilder_person(nb, member):
+    if hasattr(member, 'nation_builder_person'):
+        # Case 1: everything's ok
+        if member.nation_builder_person.nation_builder_id:
+            return
+        # Case 2: there's an attached NB record, but it's missing the NB ID
+        populate_from_nb(nb, member.email, member.nation_builder_person)
+        return
+    nb_filter = NationBuilderPerson.objects.filter(email=member.email)
+    if nb_filter.count():
+        nb_person = nb_filter[0]
+        if not nb_person.nation_builder_id:
+            # Case 4: detached record has no ID
+            populate_from_nb(nb, member.email, nb_person)
+        # Case 4, and 5: detached record has ID
+        nb_person.member = member
+        nb_person.save()
+        return
+    # Case 6: there is no NB record
+    nb_record = nb.GetFromEmail(member.email)
+    member.nation_builder_person = NationBuilderPerson(
+        member=member, email=nb_record['email'], nation_builder_id=nb_record['id'])
+    member.nation_builder_person.save()
+    member.save()
+
 # displays the member's profile page
 @login_required
 def profile(request):
@@ -284,13 +319,8 @@ def profile(request):
     nb._raise_HTTP_errors = True
     nation_builder_busy = False
     try:
-        # get the member's nation builder id if required
-        if not member.nation_builder_person.nation_builder_id:
-            member.nation_builder_person.nation_builder_id = nb.GetIdFromEmail(
-                member.email)
-            member.nation_builder_person.save()
+        ensure_nationbuilder_person(nb, member)
         member_in_nation_builder = member.nation_builder_person.nation_builder_id != None
-
         # if post...
         if request.method == 'POST':
 
@@ -371,7 +401,8 @@ def profile(request):
 
             form = MemberProfileForm(
                 instance=member, profile_fields=profile_fields)
-    except:
+    except Exception as e:
+        logging.error(e)
         nation_builder_busy = True
         member_in_nation_builder = False
 
@@ -690,7 +721,7 @@ def nation_builder_person_created(request):
         person = person_if_valid_web_hook(request)
         if person:
 
-            # ensure there is am updated linked My Momentum record for the person
+            # ensure there is an updated linked My Momentum record for the person
             ensure_my_momentum_record_for_person(person)
         else:
             return HttpResponseForbidden()

--- a/mxv/nation_builder.py
+++ b/mxv/nation_builder.py
@@ -115,15 +115,16 @@ class NationBuilder:
         self._process_response(response)
 
     # returns the NB id for an email
-    def GetIdFromEmail(self, email):
+    def GetFromEmail(self, email):
 
         # get the matching NB record
-        response = requests.get(self.MATCH_URL % (urlencode({ 'email': email }), NATIONBUILDER_API_TOKEN), timeout = self.default_timeout)
+        url = self.MATCH_URL % (urlencode({ 'email': email }), NATIONBUILDER_API_TOKEN)
+        response = requests.get(url, timeout = self.default_timeout)
         self._process_response(response)
         
         # return the requested fields if the person was found
         if response.status_code == 200:
             record = response.json()
-            return(record['person']['id'])
+            return(record['person'])
         else:
             return None

--- a/mxv/views.py
+++ b/mxv/views.py
@@ -113,7 +113,8 @@ def reconsent_complete(request):
 def redirect_to_update_details(request, unique_token):
     return HttpResponseRedirect('%s?unique_token=%s' % (reverse('members:update_details', kwargs = {'page': 1}), unique_token))
 
-# redirects to the NCG election page 
+# redirects to the NCG election page
+# TODO not sure we will ever use this: current plan is to email everyone a code
 @login_required
 def ncg_election(request):
     
@@ -126,7 +127,7 @@ def ncg_election(request):
         member = request.user
         if not member.nation_builder_person.nation_builder_id:
             nb = NationBuilder()
-            member.nation_builder_person.nation_builder_id = nb.GetIdFromEmail(member.email)
+            member.nation_builder_person.nation_builder_id = nb.GetFromEmail(member.email)['id']
             member.nation_builder_person.save()
         
         # redirect to profile if no NationBuilder id as that page has help for this situation

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "develop": "yarn python manage.py runserver",
     "migrate": "yarn python manage.py makemigrations questions && yarn python manage.py migrate",
     "psql": "psql -U mxv",
-    "python": "pipenv run python"
+    "python": "pipenv run python",
+    "test": "yarn python manage.py test"
   }
 }

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -34,7 +34,7 @@ class VotingIntentionTagTask(Task):
             if intention:
                 
                 # if this is the first access to NationBuilder and the rate limit is immediately hit then no id is returned but the email might still be known so abandon this run
-                intention.nation_builder_id = nb.GetIdFromEmail(intention.email)
+                intention.nation_builder_id = nb.GetFromEmail(intention.email)['id']
                 rate_limit_hit = nb.rate_limit_remaining == 0
                 if not rate_limit_hit:
                 


### PR DESCRIPTION
It turns out the reason for edit-profile not working was that one-to-one fields weren't being handled quite right, with an exception being thrown. The docs say to use hasattr for this case, so we do.

There were so many cases, in fact, that I decided to write the first ever mxv unit test! `yarn test` will now run unit tests. We first look up to see if there is an existing NB record for the profile, match it, correcting if needed, or create a new one.

Tested manually by `heroku pg:pull`ing the data into a local db and working off that.

Verified that this does, in fact, update the user's record in NB.